### PR TITLE
catchFlatMap when Abort (before, return ERR_EMPTY_RESPONSE)

### DIFF
--- a/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
@@ -20,7 +20,12 @@ public final class LeafErrorMiddleware: Middleware, Service {
                     return try res.encode(for: req)
                 }
             }.catchFlatMap { error in
-                return try self.handleError(for: req, status: error.localizedDescription.contains("Abort.404") ? .notFound : .forbidden)
+                switch (error) {
+                case let abort as AbortError:
+                    return try self.handleError(for: req, status: abort.status)
+                default:
+                        return try self.handleError(for: req, status: .internalServerError)
+                }
             }
         } catch {
             return try handleError(for: req, status: HTTPStatus(error))

--- a/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
@@ -19,6 +19,8 @@ public final class LeafErrorMiddleware: Middleware, Service {
                 } else {
                     return try res.encode(for: req)
                 }
+            }.catchFlatMap { error in
+                return try self.handleError(for: req, status: error.localizedDescription.contains("Abort.404") ? .notFound : .internalServerError)
             }
         } catch {
             return try handleError(for: req, status: HTTPStatus(error))

--- a/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
@@ -20,7 +20,7 @@ public final class LeafErrorMiddleware: Middleware, Service {
                     return try res.encode(for: req)
                 }
             }.catchFlatMap { error in
-                return try self.handleError(for: req, status: error.localizedDescription.contains("Abort.404") ? .notFound : .internalServerError)
+                return try self.handleError(for: req, status: error.localizedDescription.contains("Abort.404") ? .notFound : .forbidden)
             }
         } catch {
             return try handleError(for: req, status: HTTPStatus(error))

--- a/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
@@ -166,7 +166,7 @@ class LeafErrorMiddlewareTests: XCTestCase {
     
     func testThatFuture403IsCaughtCorrectly() throws {
         let response = try app.getResponse(to: "/future403")
-        XCTAssertEqual(response.http.status, .internalServerError)
+        XCTAssertEqual(response.http.status, .forbidden)
         XCTAssertEqual(viewRenderer.leafPath, "serverError")
     }
 }

--- a/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
@@ -67,7 +67,7 @@ class LeafErrorMiddlewareTests: XCTestCase {
             }
             
             router.get("future403") { req -> Future<Response> in
-                return req.future(error: Abort(.unauthorized))
+                return req.future(error: Abort(.forbidden))
             }
         }
 

--- a/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
@@ -16,6 +16,8 @@ class LeafErrorMiddlewareTests: XCTestCase {
         ("testMessageLoggedIfRendererThrows", testMessageLoggedIfRendererThrows),
         ("testThatRandomErrorGetsReturnedAsServerError", testThatRandomErrorGetsReturnedAsServerError),
         ("testThatUnauthorisedIsPassedThroughToServerErrorPage", testThatUnauthorisedIsPassedThroughToServerErrorPage),
+        ("testThatFuture404IsCaughtCorrectly", testThatFuture404IsCaughtCorrectly),
+        ("testThatFuture403IsCaughtCorrectly", testThatFuture403IsCaughtCorrectly),
     ]
     
     // MARK: - Properties
@@ -58,6 +60,14 @@ class LeafErrorMiddlewareTests: XCTestCase {
 
             router.get("unauthorized") { req -> Future<Response> in
                 throw Abort(.unauthorized)
+            }
+            
+            router.get("future404") { req -> Future<Response> in
+                return req.future(error: Abort(.notFound))
+            }
+            
+            router.get("future403") { req -> Future<Response> in
+                return req.future(error: Abort(.unauthorized))
             }
         }
 
@@ -146,6 +156,18 @@ class LeafErrorMiddlewareTests: XCTestCase {
         }
         XCTAssertEqual(contextDictionary["status"], "401")
         XCTAssertEqual(contextDictionary["statusMessage"], "Unauthorized")
+    }
+    
+    func testThatFuture404IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/future404")
+        XCTAssertEqual(response.http.status, .notFound)
+        XCTAssertEqual(viewRenderer.leafPath, "404")
+    }
+    
+    func testThatFuture403IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/future403")
+        XCTAssertEqual(response.http.status, .internalServerError)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
     }
 }
 


### PR DESCRIPTION
Before, if a route Abord, leaf-error-middleware return nothing. And the browser show:
```
This page isn’t working
localhost didn’t send any data.
ERR_EMPTY_RESPONSE
``` 