### PR TITLE
Allow Abort.redirect(…) to pass through the middleware

### DIFF
--- a/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddleware.swift
@@ -23,7 +23,7 @@ public final class LeafErrorMiddleware: Middleware, Service {
                 switch (error) {
                 case let abort as AbortError:
                     guard
-                        abort.status.isRedirect,
+                        abort.status.representsError,
                         let redirectURI = abort.headers[HTTPHeaderName.location.description].first
                     else {
                         return try self.handleError(for: req, status: abort.status)
@@ -92,7 +92,7 @@ extension HTTPStatus {
 }
 
 private extension HTTPResponseStatus {
-    var isRedirect: Bool {
-        return (HTTPResponseStatus.multiStatus.code ... HTTPResponseStatus.permanentRedirect.code) ~= code
+    var representsError: Bool {
+        return (HTTPResponseStatus.badRequest.code ... HTTPResponseStatus.networkAuthenticationRequired.code) ~= code
     }
 }

--- a/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
@@ -178,7 +178,7 @@ class LeafErrorMiddlewareTests: XCTestCase {
     func testThatRedirectIsNotCaught() throws {
         let response = try app.getResponse(to: "/future303")
         XCTAssertEqual(response.http.status, .seeOther)
-        XCTAssertEqual(response.http.body.string, "Test")
+        XCTAssertEqual(response.http.headers[.location].first, "ok")
     }
 }
 

--- a/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/LeafErrorMiddlewareTests.swift
@@ -18,6 +18,7 @@ class LeafErrorMiddlewareTests: XCTestCase {
         ("testThatUnauthorisedIsPassedThroughToServerErrorPage", testThatUnauthorisedIsPassedThroughToServerErrorPage),
         ("testThatFuture404IsCaughtCorrectly", testThatFuture404IsCaughtCorrectly),
         ("testThatFuture403IsCaughtCorrectly", testThatFuture403IsCaughtCorrectly),
+        ("testThatRedirectIsNotCaught", testThatRedirectIsNotCaught)
     ]
     
     // MARK: - Properties
@@ -68,6 +69,10 @@ class LeafErrorMiddlewareTests: XCTestCase {
             
             router.get("future403") { req -> Future<Response> in
                 return req.future(error: Abort(.forbidden))
+            }
+
+            router.get("future303") { req -> Future<Response> in
+                return req.future(error: Abort.redirect(to: "ok"))
             }
         }
 
@@ -168,6 +173,12 @@ class LeafErrorMiddlewareTests: XCTestCase {
         let response = try app.getResponse(to: "/future403")
         XCTAssertEqual(response.http.status, .forbidden)
         XCTAssertEqual(viewRenderer.leafPath, "serverError")
+    }
+
+    func testThatRedirectIsNotCaught() throws {
+        let response = try app.getResponse(to: "/future303")
+        XCTAssertEqual(response.http.status, .seeOther)
+        XCTAssertEqual(response.http.body.string, "Test")
     }
 }
 


### PR DESCRIPTION
This should solve #8.