### PR TITLE
change package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "LeafErrorMiddleware",
+    name: "leaf-error-middleware",
     platforms: [
        .macOS(.v10_15),
     ],

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ First, add LeafErrorMiddleware as a dependency in your `Package.swift` file:
 ```swift
 dependencies: [
     // ...,
-    .package(name: "LeafErrorMiddleware", url: "https://github.com/brokenhandsio/leaf-error-middleware.git", from: "2.0.0")
+    .package(url: "https://github.com/brokenhandsio/leaf-error-middleware.git", from: "2.0.0")
 ],
 targets: [
-    .target(name: "App", dependencies: ["Vapor", ..., "LeafErrorMiddleware"]),
-    // ...
-]
+.target(name: "App", dependencies: [
+    .product(name: "LeafErrorMiddleware", package: "leaf-error-middleware"),
+    // ...,
+]),
 ```
 
 To use the LeafErrorMiddleware, register the middleware service in `configure.swift` to your `Application`'s middleware (make sure you `import LeafErrorMiddleware` at the top):


### PR DESCRIPTION
I would recommend to rename the package from `LeafErrorMiddleware` to `leaf-error-middleware`. First, it will match the repository URL which seems to be important for SPM and second it will match vapor 4 dependency naming convention.  

As a result you can register it as all other vapor 4 packages.
```
// Example
...
dependencies: [
        // 💧 A server-side Swift web framework.
        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-rc"),
        .package(url: "https://github.com/vapor/leaf.git", from: "4.0.0-rc"),
        .package(url: "https://github.com/fananek/leaf-error-middleware.git", from: "2.0.0-beta")        
    ],
    targets: [
        .target(name: "App", dependencies: [
            .product(name: "Leaf", package: "leaf"),
            .product(name: "LeafErrorMiddleware", package: "leaf-error-middleware"),
            .product(name: "Vapor", package: "vapor")
        ]),
...
```