### PR TITLE
Add support for Swift 5.5 and async/await

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   xenial:
     container: 
-      image: swift:5.2-xenial
+      image: swift:5.5-xenial
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: swift test --enable-test-discovery --enable-code-coverage
   bionic:
     container: 
-      image: swift:5.4-bionic
+      image: swift:5.5-bionic
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "LeafErrorMiddleware",
     platforms: [
-       .macOS(.v10_15),
+       .macOS(.v12),
     ],
     products: [
         .library(name: "LeafErrorMiddleware", targets: ["LeafErrorMiddleware"]),

--- a/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
@@ -2,7 +2,7 @@ import Vapor
 
 @available(*, deprecated, renamed: "LeafErrorMiddlewareDefaultGenerator")
 public enum LeafErorrMiddlewareDefaultGenerator {
-    static func generate(_ status: HTTPStatus, _ error: Error, _ req: Request) -> EventLoopFuture<DefaultContext> {
+    static func generate(_ status: HTTPStatus, _ error: Error, _ req: Request) async throws -> DefaultContext {
         let reason: String?
         if let abortError = error as? AbortError {
             reason = abortError.reason
@@ -10,7 +10,7 @@ public enum LeafErorrMiddlewareDefaultGenerator {
             reason = nil
         }
         let context = DefaultContext(status: status.code.description, statusMessage: status.reasonPhrase, reason: reason)
-        return req.eventLoop.future(context )
+        return context
     }
 
     public static func build() -> LeafErrorMiddleware<DefaultContext> {
@@ -19,7 +19,7 @@ public enum LeafErorrMiddlewareDefaultGenerator {
 }
 
 public enum LeafErrorMiddlewareDefaultGenerator {
-    static func generate(_ status: HTTPStatus, _ error: Error, _ req: Request) -> EventLoopFuture<DefaultContext> {
+    static func generate(_ status: HTTPStatus, _ error: Error, _ req: Request) async throws -> DefaultContext {
         let reason: String?
         if let abortError = error as? AbortError {
             reason = abortError.reason
@@ -27,7 +27,7 @@ public enum LeafErrorMiddlewareDefaultGenerator {
             reason = nil
         }
         let context = DefaultContext(status: status.code.description, statusMessage: status.reasonPhrase, reason: reason)
-        return req.eventLoop.future(context )
+        return context
     }
 
     public static func build() -> LeafErrorMiddleware<DefaultContext> {

--- a/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
@@ -1,23 +1,5 @@
 import Vapor
 
-@available(*, deprecated, renamed: "LeafErrorMiddlewareDefaultGenerator")
-public enum LeafErorrMiddlewareDefaultGenerator {
-    static func generate(_ status: HTTPStatus, _ error: Error, _ req: Request) async throws -> DefaultContext {
-        let reason: String?
-        if let abortError = error as? AbortError {
-            reason = abortError.reason
-        } else {
-            reason = nil
-        }
-        let context = DefaultContext(status: status.code.description, statusMessage: status.reasonPhrase, reason: reason)
-        return context
-    }
-
-    public static func build() -> LeafErrorMiddleware<DefaultContext> {
-        LeafErrorMiddleware(contextGenerator: generate)
-    }
-}
-
 public enum LeafErrorMiddlewareDefaultGenerator {
     static func generate(_ status: HTTPStatus, _ error: Error, _ req: Request) async throws -> DefaultContext {
         let reason: String?

--- a/Tests/LeafErrorMiddlewareTests/CustomGeneratorTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/CustomGeneratorTests.swift
@@ -50,6 +50,10 @@ class CustomGeneratorTests: XCTestCase {
                 throw Abort(.unauthorized)
             }
 
+            router.get("303") { _ -> Response in
+                throw Abort.redirect(to: "ok")
+            }
+
             router.get("404withReason") { _ -> HTTPStatus in
                 throw Abort(.notFound, reason: "Could not find it")
             }
@@ -121,6 +125,12 @@ class CustomGeneratorTests: XCTestCase {
         let response = try app.getResponse(to: "/unknownError")
         XCTAssertEqual(response.status, .internalServerError)
         XCTAssertEqual(viewRenderer.leafPath, "serverError")
+    }
+
+    func testThatRedirectIsNotCaught() throws {
+        let response = try app.getResponse(to: "/303")
+        XCTAssertEqual(response.status, .seeOther)
+        XCTAssertEqual(response.headers[.location].first, "ok")
     }
 
     func testNonAbort404IsCaughtCorrectly() throws {

--- a/Tests/LeafErrorMiddlewareTests/CustomGeneratorTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/CustomGeneratorTests.swift
@@ -38,6 +38,10 @@ class CustomGeneratorTests: XCTestCase {
                 .notFound
             }
 
+            router.get("403") { _ -> Response in
+                throw Abort(.forbidden)
+            }
+
             router.get("serverError") { _ -> Response in
                 throw Abort(.internalServerError)
             }
@@ -137,6 +141,12 @@ class CustomGeneratorTests: XCTestCase {
         let response = try app.getResponse(to: "/404")
         XCTAssertEqual(response.status, .notFound)
         XCTAssertEqual(viewRenderer.leafPath, "404")
+    }
+
+    func testThat403IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/403")
+        XCTAssertEqual(response.status, .forbidden)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
     }
 
     func testContextGeneratedOn404Page() throws {

--- a/Tests/LeafErrorMiddlewareTests/CustomGeneratorTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/CustomGeneratorTests.swift
@@ -1,84 +1,68 @@
-import XCTest
 import LeafErrorMiddleware
-import Vapor
 @testable import Logging
+import Vapor
+import XCTest
 
 struct AContext: Encodable {
     let trigger: Bool
 }
 
 class CustomGeneratorTests: XCTestCase {
-
     // MARK: - Properties
+
     var app: Application!
     var viewRenderer: ThrowingViewRenderer!
     var logger = CapturingLogger()
     var eventLoopGroup: EventLoopGroup!
 
     // MARK: - Overrides
+
     override func setUpWithError() throws {
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         viewRenderer = ThrowingViewRenderer(eventLoop: eventLoopGroup.next())
         LoggingSystem.bootstrapInternal { _ in
-            return self.logger
+            self.logger
         }
         app = Application(.testing, .shared(eventLoopGroup))
 
         app.views.use { _ in
-            return self.viewRenderer
+            self.viewRenderer
         }
 
         func routes(_ router: RoutesBuilder) throws {
-
-            router.get("ok") { req in
-                return "ok"
+            router.get("ok") { _ in
+                "ok"
             }
 
-            router.get("404") { req -> HTTPStatus in
-                return .notFound
+            router.get("404") { _ -> HTTPStatus in
+                .notFound
             }
 
-            router.get("serverError") { req -> EventLoopFuture<Response> in
+            router.get("serverError") { _ -> Response in
                 throw Abort(.internalServerError)
             }
 
-            router.get("unknownError") { req -> EventLoopFuture<Response> in
+            router.get("unknownError") { _ -> Response in
                 throw TestError()
             }
 
-            router.get("unauthorized") { req -> EventLoopFuture<Response> in
+            router.get("unauthorized") { _ -> Response in
                 throw Abort(.unauthorized)
             }
 
-            router.get("future404") { req -> EventLoopFuture<Response> in
-                return req.eventLoop.future(error: Abort(.notFound))
-            }
-
-            router.get("future403") { req -> EventLoopFuture<Response> in
-                return req.eventLoop.future(error: Abort(.forbidden))
-            }
-
-            router.get("future303") { req -> EventLoopFuture<Response> in
-                return req.eventLoop.future(error: Abort.redirect(to: "ok"))
-            }
-
-            router.get("future404NoAbort") { req -> EventLoopFuture<HTTPStatus> in
-                return req.eventLoop.future(.notFound)
-            }
-
-            router.get("404withReason") { req -> HTTPStatus in
+            router.get("404withReason") { _ -> HTTPStatus in
                 throw Abort(.notFound, reason: "Could not find it")
             }
 
-            router.get("500withReason") { req -> HTTPStatus in
+            router.get("500withReason") { _ -> HTTPStatus in
                 throw Abort(.badGateway, reason: "I messed up")
             }
         }
 
         try routes(app)
 
-        let leafMiddleware = LeafErrorMiddleware() { status, error, req -> EventLoopFuture<AContext> in
-            return req.eventLoop.future(AContext(trigger: true))
+        let leafMiddleware = LeafErrorMiddleware { status, error, req async throws -> AContext in
+            AContext(trigger: true)
         }
         app.middleware.use(leafMiddleware)
     }
@@ -145,30 +129,6 @@ class CustomGeneratorTests: XCTestCase {
         XCTAssertEqual(viewRenderer.leafPath, "404")
     }
 
-    func testThatFuture404IsCaughtCorrectly() throws {
-        let response = try app.getResponse(to: "/future404")
-        XCTAssertEqual(response.status, .notFound)
-        XCTAssertEqual(viewRenderer.leafPath, "404")
-    }
-
-    func testFutureNonAbort404IsCaughtCorrectly() throws {
-        let response = try app.getResponse(to: "/future404NoAbort")
-        XCTAssertEqual(response.status, .notFound)
-        XCTAssertEqual(viewRenderer.leafPath, "404")
-    }
-
-    func testThatFuture403IsCaughtCorrectly() throws {
-        let response = try app.getResponse(to: "/future403")
-        XCTAssertEqual(response.status, .forbidden)
-        XCTAssertEqual(viewRenderer.leafPath, "serverError")
-    }
-
-    func testThatRedirectIsNotCaught() throws {
-        let response = try app.getResponse(to: "/future303")
-        XCTAssertEqual(response.status, .seeOther)
-        XCTAssertEqual(response.headers[.location].first, "ok")
-    }
-
     func testContextGeneratedOn404Page() throws {
         let response = try app.getResponse(to: "/404")
         XCTAssertEqual(response.status, .notFound)
@@ -189,20 +149,19 @@ class CustomGeneratorTests: XCTestCase {
         app.shutdown()
         app = Application(.testing, .shared(eventLoopGroup))
         app.views.use { _ in
-            return self.viewRenderer
+            self.viewRenderer
         }
-        let leafErrorMiddleware = LeafErrorMiddleware() { status, error, req -> EventLoopFuture<AContext> in
-            return req.eventLoop.future(error: Abort(.internalServerError))
-
+        let leafErrorMiddleware = LeafErrorMiddleware { _, _, _ -> AContext in
+            throw Abort(.internalServerError)
         }
         app.middleware = .init()
         app.middleware.use(leafErrorMiddleware)
 
-        app.get("404") { req -> EventLoopFuture<Response> in
-            req.eventLoop.makeFailedFuture(Abort(.notFound))
+        app.get("404") { _ async throws -> Response in
+            throw Abort(.notFound)
         }
-        app.get("500") { req -> EventLoopFuture<Response> in
-            req.eventLoop.makeFailedFuture(Abort(.internalServerError))
+        app.get("500") { _ async throws -> Response in
+            throw Abort(.internalServerError)
         }
 
         let response404 = try app.getResponse(to: "404")
@@ -213,6 +172,4 @@ class CustomGeneratorTests: XCTestCase {
         XCTAssertEqual(response500.status, .internalServerError)
         XCTAssertNil(viewRenderer.leafPath)
     }
-
-
 }

--- a/Tests/LeafErrorMiddlewareTests/DefaultLeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/DefaultLeafErrorMiddlewareTests.swift
@@ -34,6 +34,10 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
                 throw Abort(.notFound)
             }
 
+            router.get("403") { _ -> Response in
+                throw Abort(.forbidden)
+            }
+
             router.get("serverError") { _ -> Response in
                 throw Abort(.internalServerError)
             }
@@ -142,6 +146,12 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
         let response = try app.getResponse(to: "/404")
         XCTAssertEqual(response.status, .notFound)
         XCTAssertEqual(viewRenderer.leafPath, "404")
+    }
+
+    func testThat403IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/403")
+        XCTAssertEqual(response.status, .forbidden)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
     }
 
     func testAddingMiddlewareToRouteGroup() throws {

--- a/Tests/LeafErrorMiddlewareTests/DefaultLeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/DefaultLeafErrorMiddlewareTests.swift
@@ -31,7 +31,7 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
             }
 
             router.get("404") { _ -> HTTPStatus in
-                .notFound
+                throw Abort(.notFound)
             }
 
             router.get("serverError") { _ -> Response in
@@ -44,6 +44,10 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
 
             router.get("unauthorized") { _ -> Response in
                 throw Abort(.unauthorized)
+            }
+
+            router.get("303") { _ -> Response in
+                throw Abort.redirect(to: "ok")
             }
 
             router.get("404withReason") { _ -> HTTPStatus in
@@ -66,6 +70,12 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
     }
 
     // MARK: - Tests
+
+    func testThatRedirectIsNotCaught() throws {
+        let response = try app.getResponse(to: "/303")
+        XCTAssertEqual(response.status, .seeOther)
+        XCTAssertEqual(response.headers[.location].first, "ok")
+    }
 
     func testThatValidEndpointWorks() throws {
         let response = try app.getResponse(to: "/ok")

--- a/Tests/LeafErrorMiddlewareTests/DefaultLeafErrorMiddlewareTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/DefaultLeafErrorMiddlewareTests.swift
@@ -1,118 +1,102 @@
-import XCTest
 import LeafErrorMiddleware
-import Vapor
 @testable import Logging
+import Vapor
+import XCTest
 
 class DefaultLeafErrorMiddlewareTests: XCTestCase {
-        
     // MARK: - Properties
+
     var app: Application!
     var viewRenderer: ThrowingViewRenderer!
     var logger = CapturingLogger()
     var eventLoopGroup: EventLoopGroup!
-    
+
     // MARK: - Overrides
+
     override func setUpWithError() throws {
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         viewRenderer = ThrowingViewRenderer(eventLoop: eventLoopGroup.next())
         LoggingSystem.bootstrapInternal { _ in
-            return self.logger
+            self.logger
         }
         app = Application(.testing, .shared(eventLoopGroup))
 
         app.views.use { _ in
-            return self.viewRenderer
+            self.viewRenderer
         }
 
         func routes(_ router: RoutesBuilder) throws {
-
-            router.get("ok") { req in
-                return "ok"
-            }
-            
-            router.get("404") { req -> HTTPStatus in
-                return .notFound
+            router.get("ok") { _ in
+                "ok"
             }
 
-            router.get("serverError") { req -> EventLoopFuture<Response> in
+            router.get("404") { _ -> HTTPStatus in
+                .notFound
+            }
+
+            router.get("serverError") { _ -> Response in
                 throw Abort(.internalServerError)
             }
 
-            router.get("unknownError") { req -> EventLoopFuture<Response> in
+            router.get("unknownError") { _ -> Response in
                 throw TestError()
             }
 
-            router.get("unauthorized") { req -> EventLoopFuture<Response> in
+            router.get("unauthorized") { _ -> Response in
                 throw Abort(.unauthorized)
             }
-            
-            router.get("future404") { req -> EventLoopFuture<Response> in
-                return req.eventLoop.future(error: Abort(.notFound))
-            }
-            
-            router.get("future403") { req -> EventLoopFuture<Response> in
-                return req.eventLoop.future(error: Abort(.forbidden))
-            }
 
-            router.get("future303") { req -> EventLoopFuture<Response> in
-                return req.eventLoop.future(error: Abort.redirect(to: "ok"))
-            }
-            
-            router.get("future404NoAbort") { req -> EventLoopFuture<HTTPStatus> in
-                return req.eventLoop.future(.notFound)
-            }
-            
-            router.get("404withReason") { req -> HTTPStatus in
+            router.get("404withReason") { _ -> HTTPStatus in
                 throw Abort(.notFound, reason: "Could not find it")
             }
-            
-            router.get("500withReason") { req -> HTTPStatus in
+
+            router.get("500withReason") { _ -> HTTPStatus in
                 throw Abort(.badGateway, reason: "I messed up")
             }
         }
 
         try routes(app)
-        
+
         app.middleware.use(LeafErrorMiddlewareDefaultGenerator.build())
     }
-    
+
     override func tearDownWithError() throws {
         app.shutdown()
         try eventLoopGroup.syncShutdownGracefully()
     }
-    
+
     // MARK: - Tests
-    
+
     func testThatValidEndpointWorks() throws {
         let response = try app.getResponse(to: "/ok")
         XCTAssertEqual(response.status, .ok)
     }
-    
+
     func testThatRequestingInvalidEndpointReturns404View() throws {
         let response = try app.getResponse(to: "/unknown")
         XCTAssertEqual(response.status, .notFound)
         XCTAssertEqual(viewRenderer.leafPath, "404")
     }
-    
+
     func testThatRequestingPageThatCausesAServerErrorReturnsServerErrorView() throws {
         let response = try app.getResponse(to: "/serverError")
         XCTAssertEqual(response.status, .internalServerError)
         XCTAssertEqual(viewRenderer.leafPath, "serverError")
     }
-    
+
     func testThatErrorGetsLogged() throws {
         _ = try app.getResponse(to: "/serverError")
         XCTAssertNotNil(logger.message)
         XCTAssertEqual(logger.logLevelUsed, .error)
     }
-    
+
     func testThatMiddlewareFallsBackIfViewRendererFails() throws {
         viewRenderer.shouldThrow = true
         let response = try app.getResponse(to: "/serverError")
         XCTAssertEqual(response.status, .internalServerError)
         XCTAssertEqual(response.body.string, "<h1>Internal Error</h1><p>There was an internal error. Please try again later.</p>")
     }
-    
+
     func testThatMiddlewareFallsBackIfViewRendererFailsFor404() throws {
         viewRenderer.shouldThrow = true
         let response = try app.getResponse(to: "/unknown")
@@ -125,13 +109,13 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
         _ = try app.getResponse(to: "/serverError")
         XCTAssertTrue(logger.message?.starts(with: "Failed to render custom error page") ?? false)
     }
-    
+
     func testThatRandomErrorGetsReturnedAsServerError() throws {
         let response = try app.getResponse(to: "/unknownError")
         XCTAssertEqual(response.status, .internalServerError)
         XCTAssertEqual(viewRenderer.leafPath, "serverError")
     }
-    
+
     func testThatUnauthorisedIsPassedThroughToServerErrorPage() throws {
         let response = try app.getResponse(to: "/unauthorized")
         XCTAssertEqual(response.status, .unauthorized)
@@ -143,49 +127,25 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
         XCTAssertEqual(context.status, "401")
         XCTAssertEqual(context.statusMessage, "Unauthorized")
     }
-    
+
     func testNonAbort404IsCaughtCorrectly() throws {
         let response = try app.getResponse(to: "/404")
         XCTAssertEqual(response.status, .notFound)
         XCTAssertEqual(viewRenderer.leafPath, "404")
     }
-    
-    func testThatFuture404IsCaughtCorrectly() throws {
-        let response = try app.getResponse(to: "/future404")
-        XCTAssertEqual(response.status, .notFound)
-        XCTAssertEqual(viewRenderer.leafPath, "404")
-    }
-    
-    func testFutureNonAbort404IsCaughtCorrectly() throws {
-        let response = try app.getResponse(to: "/future404NoAbort")
-        XCTAssertEqual(response.status, .notFound)
-        XCTAssertEqual(viewRenderer.leafPath, "404")
-    }
-    
-    func testThatFuture403IsCaughtCorrectly() throws {
-        let response = try app.getResponse(to: "/future403")
-        XCTAssertEqual(response.status, .forbidden)
-        XCTAssertEqual(viewRenderer.leafPath, "serverError")
-    }
 
-    func testThatRedirectIsNotCaught() throws {
-        let response = try app.getResponse(to: "/future303")
-        XCTAssertEqual(response.status, .seeOther)
-        XCTAssertEqual(response.headers[.location].first, "ok")
-    }
-    
     func testAddingMiddlewareToRouteGroup() throws {
         app.shutdown()
         app = Application(.testing, .shared(eventLoopGroup))
         app.views.use { _ in
-            return self.viewRenderer
+            self.viewRenderer
         }
         let middlewareGroup = app.grouped(LeafErrorMiddlewareDefaultGenerator.build())
-        middlewareGroup.get("404") { req -> EventLoopFuture<Response> in
-            req.eventLoop.makeFailedFuture(Abort(.notFound))
+        middlewareGroup.get("404") { _ async throws -> Response in
+            throw Abort(.notFound)
         }
-        middlewareGroup.get("ok") { req in
-            return "OK"
+        middlewareGroup.get("ok") { _ in
+            "OK"
         }
         let validResponse = try app.getResponse(to: "ok")
         XCTAssertEqual(validResponse.status, .ok)
@@ -193,7 +153,7 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
         XCTAssertEqual(response.status, .notFound)
         XCTAssertEqual(viewRenderer.leafPath, "404")
     }
-    
+
     func testReasonIsPassedThroughTo404Page() throws {
         let response = try app.getResponse(to: "/404withReason")
         XCTAssertEqual(response.status, .notFound)
@@ -204,7 +164,7 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
         }
         XCTAssertEqual(context.reason, "Could not find it")
     }
-    
+
     func testReasonIsPassedThroughTo500Page() throws {
         let response = try app.getResponse(to: "/500withReason")
         XCTAssertEqual(response.status, .badGateway)
@@ -219,7 +179,7 @@ class DefaultLeafErrorMiddlewareTests: XCTestCase {
 
 extension Application {
     func getResponse(to path: String) throws -> Response {
-        let request = Request(application: self, method: .GET, url: URI(path: path), on: self.eventLoopGroup.next())
-        return try self.responder.respond(to: request).wait()
+        let request = Request(application: self, method: .GET, url: URI(path: path), on: eventLoopGroup.next())
+        return try responder.respond(to: request).wait()
     }
 }

--- a/Tests/LeafErrorMiddlewareTests/Fakes/CapturingLogger.swift
+++ b/Tests/LeafErrorMiddlewareTests/Fakes/CapturingLogger.swift
@@ -1,7 +1,6 @@
 import Vapor
 
 class CapturingLogger: LogHandler {
-    
     subscript(metadataKey key: String) -> Logger.Metadata.Value? {
         get { return self.metadata[key] }
         set { self.metadata[key] = newValue }

--- a/Tests/LeafErrorMiddlewareTests/Fakes/ThrowingViewRenderer.swift
+++ b/Tests/LeafErrorMiddlewareTests/Fakes/ThrowingViewRenderer.swift
@@ -1,7 +1,6 @@
 import Vapor
 
 class ThrowingViewRenderer: ViewRenderer {
-
     var shouldCache = false
     var eventLoop: EventLoop
     var shouldThrow = false
@@ -10,12 +9,12 @@ class ThrowingViewRenderer: ViewRenderer {
         self.eventLoop = eventLoop
     }
 
-    private(set) var capturedContext: Encodable? = nil
-    private(set) var leafPath: String? = nil
-    func render<E>(_ name: String, _ context: E) -> EventLoopFuture<View> where E : Encodable {
+    private(set) var capturedContext: Encodable?
+    private(set) var leafPath: String?
+    func render<E>(_ name: String, _ context: E) -> EventLoopFuture<View> where E: Encodable {
         self.capturedContext = context
         self.leafPath = name
-        if shouldThrow {
+        if self.shouldThrow {
             return self.eventLoop.makeFailedFuture(TestError())
         }
         let response = "Test"
@@ -23,7 +22,7 @@ class ThrowingViewRenderer: ViewRenderer {
         byteBuffer.writeString(response)
         return self.eventLoop.future(View(data: byteBuffer))
     }
-    
+
     func `for`(_ request: Request) -> ViewRenderer {
         return self
     }


### PR DESCRIPTION
Updated `swift-tools-version` to 5.5 and added `async/await` support to the project. 
Removed `EventLoopFuture` tests as they are redundant when using `async/await`.