### PR TITLE
Add custom mapping from errors to views

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <br>
     <br>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/Swift-5.2-brightgreen.svg" alt="Language">
+        <img src="http://img.shields.io/badge/Swift-5.6-brightgreen.svg" alt="Language">
     </a>
     <a href="https://github.com/brokenhandsio/leaf-error-middleware/actions">
         <img src="https://github.com/brokenhandsio/leaf-error-middleware/workflows/CI/badge.svg?branch=main" alt="Build Status">

--- a/README.md
+++ b/README.md
@@ -71,14 +71,31 @@ The closure receives three parameters:
 * `Error` - the error caught to be handled.
 * `Request` - the request currently being handled. This can be used to log information, make external API calls or check the session.
 
-# Setting Up
+## Custom Mappings
 
-You need to include two [Leaf](https://github.com/vapor/leaf) templates in your application:
+By default, you need to include two [Leaf](https://github.com/vapor/leaf) templates in your application:
 
 * `404.leaf`
 * `serverError.leaf`
 
-When Leaf Error Middleware catches a 404 error, it will return the `404.leaf` template. Any other error caught will return the `serverError.leaf` template. 
+However, you may elect to provide a dictionary mapping arbitrary error responses (i.e >= 400) to custom template names, like so:
+
+```swift
+let mappings: [HTTPStatus: String] = [
+    .notFound: "404",
+    .unauthorized: "401",
+    .forbidden: "403"
+]
+let leafMiddleware = LeafErrorMiddleware(errorMappings: mappings) { status, error, req async throws -> SomeContext in
+    SomeContext()
+}
+
+app.middleware.use(leafMiddleware)
+// OR
+app.middleware.use(LeafErrorMiddlewareDefaultGenerator.build(errorMappings: mapping))
+```
+
+By default, when Leaf Error Middleware catches a 404 error, it will return the `404.leaf` template. This particular mapping also allows returning a `401.leaf` or `403.leaf` template based on the error. Any other error caught will return the `serverError.leaf` template. By providing a mapping, you override the default 404 template and will need to respecify it if you want to use it.
 
 ## Default Context
 
@@ -88,4 +105,4 @@ If using the default context, the `serverError.leaf` template will be passed up 
 * `statusMessage` - a reason for the status code
 * `reason` - the reason for the error, if known. Otherwise this won't be passed in.
 
-The `404.leaf` template will get a `reason` parameter in the context if one is known.
+The `404.leaf` template and any other custom error templates will get a `reason` parameter in the context if one is known.

--- a/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
@@ -15,4 +15,8 @@ public enum LeafErrorMiddlewareDefaultGenerator {
     public static func build() -> LeafErrorMiddleware<DefaultContext> {
         LeafErrorMiddleware(contextGenerator: generate)
     }
+    
+    public static func build(errorMappings: [HTTPStatus: String]) -> LeafErrorMiddleware<DefaultContext> {
+        LeafErrorMiddleware(errorMappings: errorMappings, contextGenerator: generate)
+    }
 }

--- a/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
+++ b/Sources/LeafErrorMiddleware/LeafErrorMiddlewareDefaultGenerator.swift
@@ -12,11 +12,12 @@ public enum LeafErrorMiddlewareDefaultGenerator {
         return context
     }
 
-    public static func build() -> LeafErrorMiddleware<DefaultContext> {
-        LeafErrorMiddleware(contextGenerator: generate)
-    }
-    
-    public static func build(errorMappings: [HTTPStatus: String]) -> LeafErrorMiddleware<DefaultContext> {
-        LeafErrorMiddleware(errorMappings: errorMappings, contextGenerator: generate)
+    public static func build(errorMappings: [HTTPStatus: String]? = nil) -> LeafErrorMiddleware<DefaultContext> {
+        if let errorMappings = errorMappings {
+            return LeafErrorMiddleware(errorMappings: errorMappings, contextGenerator: generate)
+        }
+        else {
+            return LeafErrorMiddleware(contextGenerator: generate)
+        }
     }
 }

--- a/Tests/LeafErrorMiddlewareTests/CustomMappingCustomGeneratorTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/CustomMappingCustomGeneratorTests.swift
@@ -1,0 +1,148 @@
+import LeafErrorMiddleware
+@testable import Logging
+import Vapor
+import XCTest
+
+class CustomMappingCustomGeneratorTests: XCTestCase {
+    // MARK: - Properties
+
+    var app: Application!
+    var viewRenderer: ThrowingViewRenderer!
+    var logger = CapturingLogger()
+    var eventLoopGroup: EventLoopGroup!
+
+    // MARK: - Overrides
+
+    override func setUpWithError() throws {
+        eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        viewRenderer = ThrowingViewRenderer(eventLoop: eventLoopGroup.next())
+        LoggingSystem.bootstrapInternal { _ in
+            self.logger
+        }
+        app = Application(.testing, .shared(eventLoopGroup))
+
+        app.views.use { _ in
+            self.viewRenderer
+        }
+
+        func routes(_ router: RoutesBuilder) throws {
+            router.get("ok") { _ in
+                "ok"
+            }
+
+            router.get("404") { _ -> HTTPStatus in
+                .notFound
+            }
+
+            router.get("403") { _ -> Response in
+                throw Abort(.forbidden)
+            }
+
+            router.get("serverError") { _ -> Response in
+                throw Abort(.internalServerError)
+            }
+
+            router.get("unknownError") { _ -> Response in
+                throw TestError()
+            }
+
+            router.get("unauthorized") { _ -> Response in
+                throw Abort(.unauthorized)
+            }
+
+            router.get("303") { _ -> Response in
+                throw Abort.redirect(to: "ok")
+            }
+
+            router.get("404withReason") { _ -> HTTPStatus in
+                throw Abort(.notFound, reason: "Could not find it")
+            }
+
+            router.get("500withReason") { _ -> HTTPStatus in
+                throw Abort(.badGateway, reason: "I messed up")
+            }
+        }
+
+        try routes(app)
+        let mappings: [HTTPStatus: String] = [
+            .notFound: "404",
+            .unauthorized: "401",
+            .forbidden: "403",
+            // Verify that non-error mappings are ignored
+            .seeOther: "303"
+        ]
+        let leafMiddleware = LeafErrorMiddleware(errorMappings: mappings) { status, error, req async throws -> AContext in
+            AContext(trigger: true)
+        }
+        app.middleware.use(leafMiddleware)
+    }
+
+    override func tearDownWithError() throws {
+        app.shutdown()
+        try eventLoopGroup.syncShutdownGracefully()
+    }
+
+    // MARK: - Tests
+
+    func testThatValidEndpointWorks() throws {
+        let response = try app.getResponse(to: "/ok")
+        XCTAssertEqual(response.status, .ok)
+    }
+
+    func testThatRedirectIsNotCaught() throws {
+        let response = try app.getResponse(to: "/303")
+        XCTAssertEqual(response.status, .seeOther)
+        XCTAssertEqual(response.headers[.location].first, "ok")
+        XCTAssertNotEqual(viewRenderer.leafPath, "303")
+    }
+
+    func testNonAbort404IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/404")
+        XCTAssertEqual(response.status, .notFound)
+        XCTAssertEqual(viewRenderer.leafPath, "404")
+    }
+
+    func testThat403IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/403")
+        XCTAssertEqual(response.status, .forbidden)
+        XCTAssertEqual(viewRenderer.leafPath, "403")
+        let context = try XCTUnwrap(viewRenderer.capturedContext as? AContext)
+        XCTAssertTrue(context.trigger)
+    }
+
+    func testContextGeneratedOn500Page() throws {
+        let response = try app.getResponse(to: "/unauthorized")
+        XCTAssertEqual(response.status, .unauthorized)
+        XCTAssertEqual(viewRenderer.leafPath, "401")
+        let context = try XCTUnwrap(viewRenderer.capturedContext as? AContext)
+        XCTAssertTrue(context.trigger)
+    }
+
+    func testGetAResponseWhenGenerator() throws {
+        app.shutdown()
+        app = Application(.testing, .shared(eventLoopGroup))
+        app.views.use { _ in
+            self.viewRenderer
+        }
+        let leafErrorMiddleware = LeafErrorMiddleware { _, _, _ -> AContext in
+            throw Abort(.internalServerError)
+        }
+        app.middleware = .init()
+        app.middleware.use(leafErrorMiddleware)
+
+        app.get("404") { _ async throws -> Response in
+            throw Abort(.notFound)
+        }
+        app.get("500") { _ async throws -> Response in
+            throw Abort(.internalServerError)
+        }
+
+        let response404 = try app.getResponse(to: "404")
+        XCTAssertEqual(response404.status, .notFound)
+        XCTAssertNil(viewRenderer.leafPath)
+
+        let response500 = try app.getResponse(to: "500")
+        XCTAssertEqual(response500.status, .internalServerError)
+        XCTAssertNil(viewRenderer.leafPath)
+    }
+}

--- a/Tests/LeafErrorMiddlewareTests/CustomMappingCustomGeneratorTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/CustomMappingCustomGeneratorTests.swift
@@ -110,15 +110,22 @@ class CustomMappingCustomGeneratorTests: XCTestCase {
         XCTAssertTrue(context.trigger)
     }
 
-    func testContextGeneratedOn500Page() throws {
+    func testContextGeneratedOn401Page() throws {
         let response = try app.getResponse(to: "/unauthorized")
         XCTAssertEqual(response.status, .unauthorized)
         XCTAssertEqual(viewRenderer.leafPath, "401")
         let context = try XCTUnwrap(viewRenderer.capturedContext as? AContext)
         XCTAssertTrue(context.trigger)
     }
+    func testContextGeneratedOn500Page() throws {
+        let response = try app.getResponse(to: "/serverError")
+        XCTAssertEqual(response.status, .internalServerError)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
+        let context = try XCTUnwrap(viewRenderer.capturedContext as? AContext)
+        XCTAssertTrue(context.trigger)
+    }
 
-    func testGetAResponseWhenGenerator() throws {
+    func testGetAResponseWhenGeneratorThrows() throws {
         app.shutdown()
         app = Application(.testing, .shared(eventLoopGroup))
         app.views.use { _ in

--- a/Tests/LeafErrorMiddlewareTests/CustomMappingDefaultGeneratorTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/CustomMappingDefaultGeneratorTests.swift
@@ -94,7 +94,7 @@ class CustomMappingDefaultGeneratorTests: XCTestCase {
         XCTAssertEqual(viewRenderer.leafPath, "serverError")
     }
 
-    func testThatUnauthorisedIsPassedThroughToServerErrorPage() throws {
+    func testThatUnauthorisedIsPassedThroughToCustomPage() throws {
         let response = try app.getResponse(to: "/unauthorized")
         XCTAssertEqual(response.status, .unauthorized)
         XCTAssertEqual(viewRenderer.leafPath, "401")

--- a/Tests/LeafErrorMiddlewareTests/CustomMappingTests.swift
+++ b/Tests/LeafErrorMiddlewareTests/CustomMappingTests.swift
@@ -1,0 +1,205 @@
+import LeafErrorMiddleware
+@testable import Logging
+import Vapor
+import XCTest
+
+class DefaultLeafErrorMiddlewareTests: XCTestCase {
+    // MARK: - Properties
+
+    var app: Application!
+    var viewRenderer: ThrowingViewRenderer!
+    var logger = CapturingLogger()
+    var eventLoopGroup: EventLoopGroup!
+
+    // MARK: - Overrides
+
+    override func setUpWithError() throws {
+        eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        viewRenderer = ThrowingViewRenderer(eventLoop: eventLoopGroup.next())
+        LoggingSystem.bootstrapInternal { _ in
+            self.logger
+        }
+        app = Application(.testing, .shared(eventLoopGroup))
+
+        app.views.use { _ in
+            self.viewRenderer
+        }
+
+        func routes(_ router: RoutesBuilder) throws {
+            router.get("ok") { _ in
+                "ok"
+            }
+
+            router.get("404") { _ -> HTTPStatus in
+                throw Abort(.notFound)
+            }
+
+            router.get("403") { _ -> Response in
+                throw Abort(.forbidden)
+            }
+
+            router.get("serverError") { _ -> Response in
+                throw Abort(.internalServerError)
+            }
+
+            router.get("unknownError") { _ -> Response in
+                throw TestError()
+            }
+
+            router.get("unauthorized") { _ -> Response in
+                throw Abort(.unauthorized)
+            }
+
+            router.get("303") { _ -> Response in
+                throw Abort.redirect(to: "ok")
+            }
+
+            router.get("404withReason") { _ -> HTTPStatus in
+                throw Abort(.notFound, reason: "Could not find it")
+            }
+
+            router.get("500withReason") { _ -> HTTPStatus in
+                throw Abort(.badGateway, reason: "I messed up")
+            }
+        }
+
+        try routes(app)
+
+        app.middleware.use(LeafErrorMiddlewareDefaultGenerator.build())
+    }
+
+    override func tearDownWithError() throws {
+        app.shutdown()
+        try eventLoopGroup.syncShutdownGracefully()
+    }
+
+    // MARK: - Tests
+
+    func testThatRedirectIsNotCaught() throws {
+        let response = try app.getResponse(to: "/303")
+        XCTAssertEqual(response.status, .seeOther)
+        XCTAssertEqual(response.headers[.location].first, "ok")
+    }
+
+    func testThatValidEndpointWorks() throws {
+        let response = try app.getResponse(to: "/ok")
+        XCTAssertEqual(response.status, .ok)
+    }
+
+    func testThatRequestingInvalidEndpointReturns404View() throws {
+        let response = try app.getResponse(to: "/unknown")
+        XCTAssertEqual(response.status, .notFound)
+        XCTAssertEqual(viewRenderer.leafPath, "404")
+    }
+
+    func testThatRequestingPageThatCausesAServerErrorReturnsServerErrorView() throws {
+        let response = try app.getResponse(to: "/serverError")
+        XCTAssertEqual(response.status, .internalServerError)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
+    }
+
+    func testThatErrorGetsLogged() throws {
+        _ = try app.getResponse(to: "/serverError")
+        XCTAssertNotNil(logger.message)
+        XCTAssertEqual(logger.logLevelUsed, .error)
+    }
+
+    func testThatMiddlewareFallsBackIfViewRendererFails() throws {
+        viewRenderer.shouldThrow = true
+        let response = try app.getResponse(to: "/serverError")
+        XCTAssertEqual(response.status, .internalServerError)
+        XCTAssertEqual(response.body.string, "<h1>Internal Error</h1><p>There was an internal error. Please try again later.</p>")
+    }
+
+    func testThatMiddlewareFallsBackIfViewRendererFailsFor404() throws {
+        viewRenderer.shouldThrow = true
+        let response = try app.getResponse(to: "/unknown")
+        XCTAssertEqual(response.status, .notFound)
+        XCTAssertEqual(response.body.string, "<h1>Internal Error</h1><p>There was an internal error. Please try again later.</p>")
+    }
+
+    func testMessageLoggedIfRendererThrows() throws {
+        viewRenderer.shouldThrow = true
+        _ = try app.getResponse(to: "/serverError")
+        XCTAssertTrue(logger.message?.starts(with: "Failed to render custom error page") ?? false)
+    }
+
+    func testThatRandomErrorGetsReturnedAsServerError() throws {
+        let response = try app.getResponse(to: "/unknownError")
+        XCTAssertEqual(response.status, .internalServerError)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
+    }
+
+    func testThatUnauthorisedIsPassedThroughToServerErrorPage() throws {
+        let response = try app.getResponse(to: "/unauthorized")
+        XCTAssertEqual(response.status, .unauthorized)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
+        guard let context = viewRenderer.capturedContext as? DefaultContext else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(context.status, "401")
+        XCTAssertEqual(context.statusMessage, "Unauthorized")
+    }
+
+    func testNonAbort404IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/404")
+        XCTAssertEqual(response.status, .notFound)
+        XCTAssertEqual(viewRenderer.leafPath, "404")
+    }
+
+    func testThat403IsCaughtCorrectly() throws {
+        let response = try app.getResponse(to: "/403")
+        XCTAssertEqual(response.status, .forbidden)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
+    }
+
+    func testAddingMiddlewareToRouteGroup() throws {
+        app.shutdown()
+        app = Application(.testing, .shared(eventLoopGroup))
+        app.views.use { _ in
+            self.viewRenderer
+        }
+        let middlewareGroup = app.grouped(LeafErrorMiddlewareDefaultGenerator.build())
+        middlewareGroup.get("404") { _ async throws -> Response in
+            throw Abort(.notFound)
+        }
+        middlewareGroup.get("ok") { _ in
+            "OK"
+        }
+        let validResponse = try app.getResponse(to: "ok")
+        XCTAssertEqual(validResponse.status, .ok)
+        let response = try app.getResponse(to: "404")
+        XCTAssertEqual(response.status, .notFound)
+        XCTAssertEqual(viewRenderer.leafPath, "404")
+    }
+
+    func testReasonIsPassedThroughTo404Page() throws {
+        let response = try app.getResponse(to: "/404withReason")
+        XCTAssertEqual(response.status, .notFound)
+        XCTAssertEqual(viewRenderer.leafPath, "404")
+        guard let context = viewRenderer.capturedContext as? DefaultContext else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(context.reason, "Could not find it")
+    }
+
+    func testReasonIsPassedThroughTo500Page() throws {
+        let response = try app.getResponse(to: "/500withReason")
+        XCTAssertEqual(response.status, .badGateway)
+        XCTAssertEqual(viewRenderer.leafPath, "serverError")
+        guard let context = viewRenderer.capturedContext as? DefaultContext else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(context.reason, "I messed up")
+    }
+}
+
+extension Application {
+    func getResponse(to path: String) throws -> Response {
+        let request = Request(application: self, method: .GET, url: URI(path: path), on: eventLoopGroup.next())
+        return try responder.respond(to: request).wait()
+    }
+}


### PR DESCRIPTION
Adds an optional parameter to `init` as well as the `LeafMiddlewareDefaultGenerator` to provide a custom set of mappings of `HTTPStatus` to `.leaf` template names. Does not break the public API. I did this because it didn't make sense to get a 503 page when someone messes up their password.